### PR TITLE
DS1844.h wiring.h change to wiring_private.h

### DIFF
--- a/DS1844.h
+++ b/DS1844.h
@@ -7,7 +7,7 @@
 #ifndef DS1844_h
 #define DS1844_h
 #include "Arduino.h"
-#include <Wiring.h>
+#include <wiring_private.h>
 
 class DS1844
 {


### PR DESCRIPTION
The current Arduino environment does not include a wiring.h file, it was renamed to wiring_private.h. 
Developers should replace references to wiring.h with wiring_private.h